### PR TITLE
Updated scala toolchain

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.17"
-lazy val scala213 = "2.13.10"
-lazy val scala31 = "3.2.0"
+lazy val scala212 = "2.12.19"
+lazy val scala213 = "2.13.13"
+lazy val scala31 = "3.4.0"
 
 lazy val scalatestVersion = "3.2.18"
 
@@ -38,9 +38,9 @@ lazy val sha = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   ).jvmSettings(scalaVersion := scala213,
     crossScalaVersions := Seq(scala210, scala211, scala212, scala213, scala31))
   .jsSettings(scalaVersion := scala213,
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala31))
+    crossScalaVersions := Seq(scala212, scala213, scala31))
   .nativeSettings(scalaVersion := scala213,
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala31),
+    crossScalaVersions := Seq(scala212, scala213, scala31),
     nativeLinkStubs := true)
 
 lazy val bench = project.in(file("bench")).dependsOn(sha.jvm)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")


### PR DESCRIPTION
All this changes simple to delivery in one step.

Thus, modern Scala.JS and Scala-Native drop support of scala-2.11 that forces me to do the same.